### PR TITLE
Renaming for Xcode 13

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ fetchUserId().then { id in
 ```
 
 ```swift
-  let userId = try! await(fetchUserId())
+  let userId = try! avast(fetchUserId())
 ```
 
-Because async code is hard to write, hard to read, hard to reason about.   **A pain to maintain**
+Because asynchronous code is hard to write, hard to read, hard to reason about. **A pain to maintain**
 
 ## Try it
 then is part of [freshOS](https://freshos.github.io/) iOS toolset. Try it in an example App! <a class="github-button" href="https://github.com/freshOS/StarterProject/archive/master.zip" data-icon="octicon-cloud-download" data-style="mega" aria-label="Download freshOS/StarterProject on GitHub">Download Starter Project</a>
 
 ## How
 By using a **then** keyword that enables you to write aSync code that *reads like an English sentence*  
-Async code is now **concise**, **flexible** and **maintainable** ❤️
+Asynchronous code is now **concise**, **flexible** and **maintainable** ❤️
 
 ## What
 - [x] Based on the popular `Promise` / `Future` concept
-- [x] `Async` / `Await`
+- [x] `Ahoy` / `avast`
 - [x] `progress` `race` `recover` `validate` `retry` `bridgeError` `chain` `noMatterWhat` ...
 - [x] Strongly Typed
 - [x] Pure Swift & Lightweight
@@ -124,8 +124,8 @@ Mental sanity saved
   7. [chain](#chain)
   8. [noMatterWhat](#nomatterwhat)
   9. [unwrap](#unwrap)
-6. [AsyncTask](#asynctask)
-7. [Async/Await](#async/await)
+6. [AhoyTask](#ahoytask)
+7. [Ahoy/avast](#ahoy/avast)
 
 ### Writing your own Promise 💪
 Wondering what fetchUserId() is?  
@@ -295,7 +295,7 @@ A common use-case is for adding Analytics tracking like so:
 
 ```swift
 extension Photo {
-    public func post() -> Async<Photo> {
+    public func post() -> Ahoy<Photo> {
         return api.post(self).chain { _ in
             Tracker.trackEvent(.postPicture)
         }
@@ -333,37 +333,37 @@ func fetch(userId: String?) -> Promise<Void> {
 ```
 Unwrap will fail the promise chain with `unwrappingFailed` error in case of a nil value :)
 
-### AsyncTask
-`AsyncTask` and `Async<T>` typealisases are provided for those of us who think that Async can be clearer than `Promise`.
-Feel free to replace `Promise<Void>` by `AsyncTask` and `Promise<T>` by `Async<T>` wherever needed.  
+### AhoyTask
+`AhoyTask` and `Ahoy<T>` typealisases are provided for those of us who think that `Ahoy` can be clearer than `Promise`.
+Feel free to replace `Promise<Void>` by `AhoyTask` and `Promise<T>` by `Ahoy<T>` wherever needed.  
 This is purely for the eyes :)
 
 
-### Async/Await
+### Ahoy/avast
 
-`await` waits for a promise to complete synchronously and yields the result :
+`avast` waits for a promise to complete synchronously and yields the result :
 
 ```swift
-let photos = try! await(getPhotos())
+let photos = try! avast(getPhotos())
 ```
 
-`async` takes a block and wraps it in a background Promise.
+`ahoy` takes a block and wraps it in a background Promise.
 
 ```swift
-async {
-  let photos = try await(getPhotos())
+ahoy {
+  let photos = try avast(getPhotos())
 }
 ```
-Notice how we don't need the `!` anymore because `async` will catch the errors.
+Notice how we don't need the `!` anymore because `ahoy` will catch the errors.
 
 
-Together, `async`/`await` enable us to write asynchronous code in a synchronous manner :
+Together, `ahoy`/`avast` enable us to write ahoyhronous code in a synchronous manner :
 
 ```swift
-async {
-  let userId = try await(fetchUserId())
-  let userName = try await(fetchUserNameFromId(userId))
-  let isFollowed = try await(fetchUserFollowStatusFromName(userName))
+ahoy {
+  let userId = try avast(fetchUserId())
+  let userName = try avast(fetchUserNameFromId(userId))
+  let isFollowed = try avast(fetchUserFollowStatusFromName(userName))
   return isFollowed
 }.then { isFollowed in
   print(isFollowed)
@@ -372,10 +372,10 @@ async {
 }
 ```
 
-#### Await operators
-Await comes with `..` shorthand operator. The `..?` will fallback to a nil value instead of throwing.
+#### avast operators
+avast comes with `..` shorthand operator. The `..?` will fallback to a nil value instead of throwing.
 ```swift
-let userId = try await(fetchUserId())
+let userId = try avast(fetchUserId())
 ```
 Can be written like this:
 ```swift

--- a/Sources/Then/Ahoy.swift
+++ b/Sources/Then/Ahoy.swift
@@ -1,5 +1,5 @@
 //
-//  Async.swift
+//  Ahoy.swift
 //  then
 //
 //  Created by Sacha Durand Saint Omer on 13/03/2017.
@@ -10,9 +10,9 @@ import Foundation
 import Dispatch
 
 @discardableResult
-public func async<T>(block:@escaping () throws -> T) -> Async<T> {
+public func ahoy<T>(block:@escaping () throws -> T) -> Ahoy<T> {
     let p = Promise<T> { resolve, reject in
-        DispatchQueue(label: "then.async.queue", attributes: .concurrent).async {
+        DispatchQueue(label: "then.ahoy.queue", attributes: .concurrent).async {
             do {
                 let t = try block()
                 resolve(t)

--- a/Sources/Then/Avast+Operators.swift
+++ b/Sources/Then/Avast+Operators.swift
@@ -1,5 +1,5 @@
 //
-//  Await+Operators.swift
+//  Avast+Operators.swift
 //  then
 //
 //  Created by Sacha DSO on 30/05/2018.
@@ -11,19 +11,19 @@ import Foundation
 prefix operator ..
 
 public prefix func .. <T>(promise: Promise<T>) throws -> T {
-    return try await(promise)
+    return try avast(promise)
 }
 
 public prefix func .. <T>(promise: Promise<T>?) throws -> T {
     guard let promise = promise else { throw PromiseError.unwrappingFailed }
-    return try await(promise)
+    return try avast(promise)
 }
 
 prefix operator ..?
 
 public prefix func ..? <T>(promise: Promise<T>) -> T? {
     do {
-        return try await(promise)
+        return try avast(promise)
     } catch {
         return nil
     }
@@ -32,7 +32,7 @@ public prefix func ..? <T>(promise: Promise<T>) -> T? {
 public prefix func ..? <T>(promise: Promise<T>?) -> T? {
     guard let promise = promise else { return nil }
     do {
-        return try await(promise)
+        return try avast(promise)
     } catch {
         return nil
     }

--- a/Sources/Then/Avast.swift
+++ b/Sources/Then/Avast.swift
@@ -1,5 +1,5 @@
 //
-//  Await.swift
+//  Avast.swift
 //  then
 //
 //  Created by Sacha Durand Saint Omer on 13/03/2017.
@@ -9,7 +9,7 @@
 import Foundation
 import Dispatch
 
-@discardableResult public func await<T>(_ promise: Promise<T>) throws -> T {
+@discardableResult public func avast<T>(_ promise: Promise<T>) throws -> T {
     var result: T!
     var error: Error?
     let group = DispatchGroup()

--- a/Sources/Then/Promise+Aliases.swift
+++ b/Sources/Then/Promise+Aliases.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public typealias EmptyPromise = Promise<Void>
-public typealias Async<T> = Promise<T>
-public typealias AsyncTask = Async<Void>
+public typealias Ahoy<T> = Promise<T>
+public typealias AhoyTask = Ahoy<Void>

--- a/Tests/ThenTests/AsyncAwaitTests.swift
+++ b/Tests/ThenTests/AsyncAwaitTests.swift
@@ -1,5 +1,5 @@
 //
-//  AsyncAwaitTests.swift
+//  AhoyAvastTests.swift
 //  then
 //
 //  Created by Sacha Durand Saint Omer on 13/03/2017.
@@ -9,60 +9,60 @@
 import XCTest
 import Then
 
-class AsyncAwaitTests: XCTestCase {
+class AhoyAvastTests: XCTestCase {
     
-    func testAsyncAwaitChainWorks() {
+    func testAhoyAvastChainWorks() {
         let exp = expectation(description: "")
-        async {
-            let userId = try await(fetchUserId())
+        ahoy {
+            let userId = try avast(fetchUserId())
             XCTAssertEqual(userId, 1234)
-            let userName = try await(fetchUserNameFromId(userId))
+            let userName = try avast(fetchUserNameFromId(userId))
             XCTAssertEqual(userName, "John Smith")
-            let isFollowed = try await(fetchUserFollowStatusFromName(userName))
+            let isFollowed = try avast(fetchUserFollowStatusFromName(userName))
             XCTAssertFalse(isFollowed)
             exp.fulfill()
         }
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testFailingAsyncAwait() {
+    func testFailingAhoyAvast() {
         let exp = expectation(description: "")
-        async {
-            _ = try await(failingFetchUserFollowStatusFromName("JohnDoe"))
-            XCTFail("testFailingAsyncAwait failed")
+        ahoy {
+            _ = try avast(failingFetchUserFollowStatusFromName("JohnDoe"))
+            XCTFail("testFailingAhoyAvast failed")
         }.onError { _ in
             exp.fulfill()
         }
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testCatchFailingAsyncAwait() {        
+    func testCatchFailingAhoyAvast() {
         let exp = expectation(description: "")
         do {
-            _ = try await(failingFetchUserFollowStatusFromName("JohnDoe"))
-            XCTFail("testCatchFailingAsyncAwait failed")
+            _ = try avast(failingFetchUserFollowStatusFromName("JohnDoe"))
+            XCTFail("testCatchFailingAhoyAvast failed")
         } catch {
             exp.fulfill()
         }
         waitForExpectations(timeout: 0.3, handler: nil)
     }
     
-    func testAsyncAwaitUnwrapAtYourOwnRisk() {
+    func testAhoyAvastUnwrapAtYourOwnRisk() {
         let exp = expectation(description: "")
-        let userId = try! await(fetchUserId())
+        let userId = try! avast(fetchUserId())
         XCTAssertEqual(userId, 1234)
-        let userName = try! await(fetchUserNameFromId(userId))
+        let userName = try! avast(fetchUserNameFromId(userId))
         XCTAssertEqual(userName, "John Smith")
-        let isFollowed = try! await(fetchUserFollowStatusFromName(userName))
+        let isFollowed = try! avast(fetchUserFollowStatusFromName(userName))
         XCTAssertFalse(isFollowed)
         exp.fulfill()
         waitForExpectations(timeout: 0.3, handler: nil)
     }
     
-    func testAsyncBlockCanReturnAValue() {
+    func testAhoyBlockCanReturnAValue() {
         let exp = expectation(description: "")
-        async { () -> Int in
-            let userId = try await(fetchUserId())
+        ahoy { () -> Int in
+            let userId = try avast(fetchUserId())
             return userId
         }.then { userId in
             XCTAssertEqual(userId, 1234)
@@ -73,9 +73,9 @@ class AsyncAwaitTests: XCTestCase {
     
     /// Operator ..
     
-    func testAsyncAwaitChainWorksOperator() {
+    func testAhoyAvastChainWorksOperator() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let userId = try ..fetchUserId()
             XCTAssertEqual(userId, 1234)
             let userName = try ..fetchUserNameFromId(userId)
@@ -87,29 +87,29 @@ class AsyncAwaitTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testFailingAsyncAwaitOperator() {
+    func testFailingAhoyAvastOperator() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             _ = try ..failingFetchUserFollowStatusFromName("JohnDoe")
-            XCTFail("testFailingAsyncAwait failed")
+            XCTFail("testFailingAhoyAvast failed")
         }.onError { _ in
             exp.fulfill()
         }
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
-    func testCatchFailingAsyncAwaitOperator() {
+    func testCatchFailingAhoyAvastOperator() {
         let exp = expectation(description: "")
         do {
             _ = try ..failingFetchUserFollowStatusFromName("JohnDoe")
-            XCTFail("testCatchFailingAsyncAwait failed")
+            XCTFail("testCatchFailingAhoyAvast failed")
         } catch {
             exp.fulfill()
         }
         waitForExpectations(timeout: 0.3, handler: nil)
     }
 
-    func testAsyncAwaitUnwrapAtYourOwnRiskOperator() {
+    func testAhoyAvastUnwrapAtYourOwnRiskOperator() {
         let exp = expectation(description: "")
         let userId = try! ..fetchUserId()
         XCTAssertEqual(userId, 1234)
@@ -121,9 +121,9 @@ class AsyncAwaitTests: XCTestCase {
         waitForExpectations(timeout: 0.3, handler: nil)
     }
 
-    func testAsyncBlockCanReturnAValueOperator() {
+    func testAhoyBlockCanReturnAValueOperator() {
         let exp = expectation(description: "")
-        async { () -> Int in
+        ahoy { () -> Int in
             let userId = try ..fetchUserId()
             return userId
         }.then { userId in
@@ -137,7 +137,7 @@ class AsyncAwaitTests: XCTestCase {
     
     func testOptionalPromises() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let optionalPromise: Promise? = fetchUserId()
             let userId = try ..optionalPromise
             XCTAssertEqual(userId, 1234)
@@ -148,10 +148,10 @@ class AsyncAwaitTests: XCTestCase {
     
     func testNilOptionalPromisesFail() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let optionalPromise: Promise<Int>? = nil
             _ = try ..optionalPromise
-            XCTFail("testFailingAsyncAwait failed")
+            XCTFail("testFailingAhoyAvast failed")
         }.onError { _ in
             exp.fulfill()
         }
@@ -160,9 +160,9 @@ class AsyncAwaitTests: XCTestCase {
     
     /// Operator ..? - nils out instead of throwing
     
-    func testAwaitNilingOperator() {
+    func testAvastNilingOperator() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let userId = ..?fetchUserId()
             XCTAssertEqual(userId, 1234)
             exp.fulfill()
@@ -170,23 +170,23 @@ class AsyncAwaitTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testAwaitNilingOperatorError() {
+    func testAvastNilingOperatorError() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let string = ..?(failingFetchUserFollowStatusFromName("JohnDoe"))
             XCTAssertNil(string)
             exp.fulfill()
         }.onError { _ in
-            XCTFail("testFailingAsyncAwait failed")
+            XCTFail("testFailingAhoyAvast failed")
         }
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     /// Optional Operator ..? - nils out instead of throwing
     
-    func testAwaitNilingOperatorOptional() {
+    func testAvastNilingOperatorOptional() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let promise: Promise<Int>? = fetchUserId()
             let userId = ..?promise
             XCTAssertEqual(userId, 1234)
@@ -195,28 +195,28 @@ class AsyncAwaitTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testAwaitNilingOperatorErrorOptinal() {
+    func testAvastNilingOperatorErrorOptinal() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let promise: Promise<Bool>? = failingFetchUserFollowStatusFromName("JohnDoe")
             let string = ..?promise
             XCTAssertNil(string)
             exp.fulfill()
         }.onError { _ in
-            XCTFail("testFailingAsyncAwait failed")
+            XCTFail("testFailingAhoyAvast failed")
         }
         waitForExpectations(timeout: 0.5, handler: nil)
     }
     
-    func testAwaitNilingOperatorErrorNilOptional() {
+    func testAvastNilingOperatorErrorNilOptional() {
         let exp = expectation(description: "")
-        async {
+        ahoy {
             let promise: Promise<Bool>? = nil
             let string = ..?promise
             XCTAssertNil(string)
             exp.fulfill()
         }.onError { _ in
-            XCTFail("testFailingAsyncAwait failed")
+            XCTFail("testFailingAhoyAvast failed")
         }
         waitForExpectations(timeout: 0.3, handler: nil)
     }

--- a/Tests/ThenTests/ChainTests.swift
+++ b/Tests/ThenTests/ChainTests.swift
@@ -39,10 +39,10 @@ class ChainTests: XCTestCase {
         waitForExpectations(timeout: 0.3, handler: nil)
     }
     
-    func testChainNotCalledWhenAsyncPromiseFails() {
+    func testChainNotCalledWhenAhoyPromiseFails() {
         let exp = expectation(description: "")
         failingFetchUserFollowStatusFromName("Tom").chain { _ in
-            XCTFail("testChainNotCalledWhenAsyncPromiseFails failed")
+            XCTFail("testChainNotCalledWhenAhoyPromiseFails failed")
         }.onError { _ in
             exp.fulfill()
         }


### PR DESCRIPTION
* Rename `async`/`await` to `ahoy`/`avast`
* Also bumped support from iOS 8 to 11